### PR TITLE
WIP Feat/indexed global rankings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 
 ## system files
 .DS_Store
+.envrc
+.tool-versions
+shell.nix
 
 ## holochain files
 .hc*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,8 +536,8 @@ dependencies = [
 
 [[package]]
 name = "hc_time_index"
-version = "0.2.0"
-source = "git+https://github.com/mattyg/holochain-time-index.git?branch=develop#077c9e62868ca5201ff23f93d1d687f4eef4ef09"
+version = "0.1.0"
+source = "git+https://github.com/holochain-open-dev/holochain-time-index.git#e814be16d919ba33c0e0a3fe38b7beb3cd9c54cb"
 dependencies = [
  "chrono",
  "hdi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hc_lib_ranking_index"
+version = "0.3.0"
+source = "git+https://github.com/mattyg/ranking-index?branch=feat/support-anylinkablehash-hc-175#d1615665b0a40b4affb460e5978d3bcd56741197"
+dependencies = [
+ "hdk",
+ "serde",
+]
+
+[[package]]
 name = "hc_time_index"
 version = "0.1.0"
 source = "git+https://github.com/holochain-open-dev/holochain-time-index.git#e814be16d919ba33c0e0a3fe38b7beb3cd9c54cb"
@@ -940,11 +949,14 @@ version = "0.0.1"
 dependencies = [
  "chrono",
  "derive_more",
+ "hc_lib_ranking_index",
  "hc_time_index",
  "hdk",
  "mews_integrity",
  "regex",
  "serde",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -953,6 +965,8 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "serde",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1418,6 +1432,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +469,12 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -520,6 +532,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hc_time_index"
+version = "0.2.0"
+source = "git+https://github.com/mattyg/holochain-time-index.git?branch=develop#077c9e62868ca5201ff23f93d1d687f4eef4ef09"
+dependencies = [
+ "chrono",
+ "hdi",
+ "hdk",
+ "lazy_static",
+ "mut_static",
+ "permutation",
+ "petgraph",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -910,7 +938,9 @@ dependencies = [
 name = "mews"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "derive_more",
+ "hc_time_index",
  "hdk",
  "mews_integrity",
  "regex",
@@ -939,6 +969,15 @@ name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "mut_static"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248cd8eb389a4e3618bba47c9a171a4bbb271c29c07e03c4ff4ff74946336f66"
+dependencies = [
+ "error-chain",
+]
 
 [[package]]
 name = "num-integer"
@@ -1024,6 +1063,22 @@ name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
+name = "permutation"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9978962f8a4b158e97447a6d09d2d75e206d2994eff056c894019f362b27142"
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project-lite"

--- a/dnas/clutter/coordinator_zomes/mews/Cargo.toml
+++ b/dnas/clutter/coordinator_zomes/mews/Cargo.toml
@@ -12,6 +12,9 @@ derive_more = "0"
 regex = "1"
 serde = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
+strum = "0.24"
+strum_macros = "0.24"
 mews_integrity = {path = "../../integrity_zomes/mews"}
 hdk = {version = "0.0.163", features = ["encoding"]}
 hc_time_index = {git = "https://github.com/holochain-open-dev/holochain-time-index.git", package = "hc_time_index"}
+hc_lib_ranking_index = {git = "https://github.com/mattyg/ranking-index", branch = "feat/support-anylinkablehash-hc-175", package = "hc_lib_ranking_index"}

--- a/dnas/clutter/coordinator_zomes/mews/Cargo.toml
+++ b/dnas/clutter/coordinator_zomes/mews/Cargo.toml
@@ -11,6 +11,7 @@ name = "mews"
 derive_more = "0"
 regex = "1"
 serde = "1"
-
+chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 mews_integrity = {path = "../../integrity_zomes/mews"}
 hdk = {version = "0.0.163", features = ["encoding"]}
+hc_time_index = {git = "https://github.com/mattyg/holochain-time-index.git", branch = "develop", package = "hc_time_index"}

--- a/dnas/clutter/coordinator_zomes/mews/Cargo.toml
+++ b/dnas/clutter/coordinator_zomes/mews/Cargo.toml
@@ -14,4 +14,4 @@ serde = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 mews_integrity = {path = "../../integrity_zomes/mews"}
 hdk = {version = "0.0.163", features = ["encoding"]}
-hc_time_index = {git = "https://github.com/mattyg/holochain-time-index.git", branch = "develop", package = "hc_time_index"}
+hc_time_index = {git = "https://github.com/holochain-open-dev/holochain-time-index.git", package = "hc_time_index"}

--- a/dnas/clutter/coordinator_zomes/mews/src/lib.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/lib.rs
@@ -10,9 +10,9 @@ use time_index::*;
 #[hdk_extern]
 fn init(_: ()) -> ExternResult<InitCallbackResult> {
     let _index = get_current_index(
-        "index_mews_by_timestamp".into(), 
+        TIME_INDEX_NAME.into(), 
         None,
-        LinkTypes::TimeIndex
+        TIME_INDEX_PATH_LINK_TYPE
     );
 
     Ok(InitCallbackResult::Pass)
@@ -86,7 +86,7 @@ pub fn create_mew(mew: CreateMewInput) -> ExternResult<ActionHash> {
     let mew_record = get(mew_action_hash.clone(), GetOptions { strategy: GetStrategy::Content })?
         .ok_or(wasm_error!(WasmErrorInner::Guest("Failed to get mew_record".into())))?;
     let indexable_mew_record = IndexableRecord::from(mew_record);
-    let _result = index_entry("index_mews_by_timestamp".into(), indexable_mew_record, (), LinkTypes::TimeIndexToMew, LinkTypes::TimeIndex)
+    let _result = index_entry(TIME_INDEX_NAME.into(), indexable_mew_record, (), TIME_INDEX_LINK_TYPE, TIME_INDEX_PATH_LINK_TYPE)
         .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.into())))?;
     
     Ok(mew_action_hash)
@@ -300,13 +300,13 @@ pub fn most_licked_mews_recently(input: MostLickedMewsRecentlyInput) -> ExternRe
 
     // Get all mews with created in last 24 hours
     let mew_links: Vec<Link> = get_links_for_time_span(
-        "index_mews_by_timestamp".into(), 
+        TIME_INDEX_NAME.into(), 
         from_datetime, 
         until_datetime,
         None,
         None,
-        LinkTypes::TimeIndexToMew,
-        LinkTypes::TimeIndex
+        TIME_INDEX_LINK_TYPE,
+        TIME_INDEX_PATH_LINK_TYPE,
     ).map_err(|e| wasm_error!(WasmErrorInner::Guest(e.into())))?;
     let mew_records: Vec<Record> = mew_links
         .into_iter()

--- a/dnas/clutter/coordinator_zomes/mews/src/lib.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/lib.rs
@@ -745,7 +745,13 @@ pub fn check_generate_rankings(ranking_type: MewRanking, base_path: Path, date_r
 /// Trust Model:
 ///     - Inclusion of entries in rankings list: 1/N (where N is the number of agents generating ranking indices for a round)
 ///     - Sorting of rankings list: 0/N (every agent performs their own sorting and top X selection)
-pub fn get_rankings_consensus(ranking_type: MewRanking, base_path: Path, count: u32) -> ExternResult<Vec<FeedMew>> {
+pub fn get_rankings_consensus(ranking_type: MewRanking, base_path: Path) -> ExternResult<Vec<FeedMew>> {
+    // Get DNA properties
+    let dna_properties = DnaProperties::try_from(dna_info()?.properties)
+        .map_err(|err| wasm_error!(WasmErrorInner::Guest(err.into())))?;
+    let count = dna_properties.ranking_count;
+    
+
     // Ensure base_path exists
     let ranking_link_type = match ranking_type {
         MewRanking::MostLicks => LinkTypes::RankingIndexMewsMostLicks,
@@ -777,4 +783,37 @@ pub fn get_rankings_consensus(ranking_type: MewRanking, base_path: Path, count: 
     let feedmews_ranked_counted = feedmews.into_iter().take(count.try_into().unwrap()).collect();
 
     Ok(feedmews_ranked_counted)
+}
+
+#[hdk_extern]
+pub fn get_rankings_consensus_by_year(input: GetRankedMewsByYearInput) -> ExternResult<Vec<FeedMew>> {
+    get_rankings_consensus(
+        input.ranking_type,
+        Path::from(format!("rankings_index.by_year.{}", input.year))
+    )
+}
+
+#[hdk_extern]
+pub fn get_rankings_consensus_by_month(input: GetRankedMewsByMonthInput) -> ExternResult<Vec<FeedMew>> {
+    get_rankings_consensus(
+        input.ranking_type,
+        Path::from(format!("rankings_index.by_month.{}.{}", input.year, input.month))
+    )
+}
+
+#[hdk_extern]
+pub fn get_rankings_consensus_by_week(input: GetRankedMewsByWeekInput) -> ExternResult<Vec<FeedMew>> {
+    get_rankings_consensus(
+        input.ranking_type,
+        Path::from(format!("rankings_index.by_week.{}.{}", input.year, input.iso_week))
+
+    )
+}
+
+#[hdk_extern]
+pub fn get_rankings_consensus_by_day(input: GetRankedMewsByDayInput) -> ExternResult<Vec<FeedMew>> {
+    get_rankings_consensus(
+        input.ranking_type,
+        Path::from(format!("rankings_index.by_day.{}.{}", input.year, input.ordinal))
+    )
 }

--- a/dnas/clutter/coordinator_zomes/mews/src/lib.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/lib.rs
@@ -284,14 +284,14 @@ pub fn mews_feed(_options: FeedOptions) -> ExternResult<Vec<FeedMew>> {
 #[hdk_extern]
 pub fn most_licked_mews_recently(input: MostLickedMewsRecentlyInput) -> ExternResult<Vec<FeedMew>> {
     let timestamp = sys_time()?.as_seconds_and_nanos();
-    let current_datetime = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp.0, timestamp.1), Utc);
-    let yesterday_datetime = current_datetime - Duration::hours(input.from_hours_ago.into());
+    let until_datetime = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp.0, timestamp.1), Utc);
+    let from_datetime = until_datetime - Duration::seconds(input.from_seconds_ago.into());
 
     // Get all mews with created in last 24 hours
     let mew_links: Vec<Link> = get_links_for_time_span(
         "index_mews_by_timestamp".into(), 
-        yesterday_datetime, 
-        current_datetime,
+        from_datetime, 
+        until_datetime,
         None,
         None,
         LinkTypes::TimeIndexToMew,

--- a/dnas/clutter/coordinator_zomes/mews/src/lib.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/lib.rs
@@ -7,6 +7,17 @@ use chrono::{NaiveDateTime, DateTime, Duration, Utc};
 mod time_index;
 use time_index::*;
 
+#[hdk_extern]
+fn init(_: ()) -> ExternResult<InitCallbackResult> {
+    let _index = get_current_index(
+        "index_mews_by_timestamp".into(), 
+        None,
+        LinkTypes::TimeIndex
+    );
+
+    Ok(InitCallbackResult::Pass)
+}
+
 fn get_my_mews_base(base_type: &str, ensure: bool) -> ExternResult<EntryHash> {
     let me: AgentPubKey = agent_info()?.agent_latest_pubkey;
     get_mews_base(me.into(), base_type, ensure)

--- a/dnas/clutter/coordinator_zomes/mews/src/lib.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/lib.rs
@@ -310,7 +310,7 @@ fn mews_recently_created(input: GetRecentMewsInput) -> ExternResult<Vec<FeedMew>
     
     let feedmews: Vec<FeedMew> = mew_links
         .into_iter()
-        .filter_map(|l| get(ActionHash::from(l.target), GetOptions { ..Default::default() }).unwrap_or(None))
+        .filter_map(|l| get(EntryHash::from(l.target), GetOptions { ..Default::default() }).unwrap_or(None))
         .map(|record| get_feed_mew_and_context(record.action_hashed().hash.clone()).unwrap())
         .collect();
 

--- a/dnas/clutter/coordinator_zomes/mews/src/lib.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/lib.rs
@@ -694,7 +694,7 @@ pub fn check_generate_rankings(ranking_type: MewRanking, base_path: Path, date_r
     // Get DNA properties
     let dna_properties = DnaProperties::try_from(dna_info()?.properties)
         .map_err(|err| wasm_error!(WasmErrorInner::Guest(err.into())))?;
-    let ranking_agents_count = dna_properties.ranking_agents_count;
+    let redundant_rankings_count = dna_properties.redundant_rankings_count;
     let ranking_count = dna_properties.ranking_count;
     
     // Ensure base_path exists
@@ -707,9 +707,9 @@ pub fn check_generate_rankings(ranking_type: MewRanking, base_path: Path, date_r
     let typed_base_path = base_path.clone().typed(ranking_link_type)?;
     typed_base_path.ensure()?;
 
-    // Check if there are already RANKING_AGENTS_COUNT redundant ranking indexes
+    // Check if there are already redundant_rankings_count redundant ranking indexes
     let existing_ranking_agents = get_links(typed_base_path.path_entry_hash()?, ranking_link_type, None)?;
-    if existing_ranking_agents.len() < ranking_agents_count {                 
+    if existing_ranking_agents.len() < redundant_rankings_count {                 
         // Generate new ranking index
         let ranking_index = RankingIndex::new_with_default_mod(ScopedLinkType::try_from(ranking_link_type)?);
 

--- a/dnas/clutter/coordinator_zomes/mews/src/lib.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/lib.rs
@@ -298,6 +298,11 @@ fn mews_recently_created(input: GetRecentMewsInput) -> ExternResult<Vec<FeedMew>
     let from_datetime = until_datetime - Duration::seconds(input.from_seconds_ago.into());
 
     // Get all mews with created in last 24 hours
+    mews_created_in_date_range(from_datetime, until_datetime)
+}
+
+
+fn mews_created_in_date_range(from_datetime: DateTime<Utc>, until_datetime: DateTime<Utc>) -> ExternResult<Vec<FeedMew>> {
     let mew_links: Vec<Link> = get_links_for_time_span(
         TIME_INDEX_NAME.into(), 
         from_datetime, 

--- a/dnas/clutter/coordinator_zomes/mews/src/lib.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/lib.rs
@@ -268,6 +268,23 @@ pub fn mews_feed(_options: FeedOptions) -> ExternResult<Vec<FeedMew>> {
     Ok(feed)
 }
 
+#[hdk_extern]
+pub fn most_licked_mews_feed(count: usize) -> ExternResult<Vec<FeedMew>> {
+    // Get mews from feed, with at least 1 lick, sorted by licks count descending
+    let mews_feed = mews_feed(FeedOptions { option: "".into() })?;
+    let mut mews_with_licks: Vec<FeedMew> = mews_feed
+        .clone()
+        .into_iter()
+        .filter(|a| a.licks.len() > 0)
+        .collect(); 
+    mews_with_licks.sort_by(|a, b| b.licks.len().cmp(&a.licks.len()));
+
+    // Take first mews up to 'count'
+    let most_licked_mews_feed = mews_with_licks.into_iter().take(count).collect();
+    
+    Ok(most_licked_mews_feed)
+}
+
 // *** Liking ***
 
 #[hdk_extern]

--- a/dnas/clutter/coordinator_zomes/mews/src/time_index.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/time_index.rs
@@ -1,6 +1,11 @@
 use hdk::prelude::*;
 use chrono::{NaiveDateTime, DateTime, Utc};
 use hc_time_index::IndexableEntry;
+use mews_integrity::LinkTypes;
+
+pub const TIME_INDEX_NAME: &str = "index_mews_by_timestamp";
+pub const TIME_INDEX_LINK_TYPE: LinkTypes = LinkTypes::TimeIndexToMew;
+pub const TIME_INDEX_PATH_LINK_TYPE: LinkTypes = LinkTypes::TimeIndex;
 
 #[derive(Serialize, Deserialize, Debug, Clone, SerializedBytes)]
 pub struct IndexableRecord {

--- a/dnas/clutter/coordinator_zomes/mews/src/time_index.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/time_index.rs
@@ -1,0 +1,31 @@
+use hdk::prelude::*;
+use chrono::{NaiveDateTime, DateTime, Utc};
+use hc_time_index::IndexableEntry;
+
+#[derive(Serialize, Deserialize, Debug, Clone, SerializedBytes)]
+pub struct IndexableRecord {
+    pub record_datetime: DateTime<Utc>,
+    pub record_ah: ActionHash,
+}
+
+impl From<Record> for IndexableRecord {
+  fn from(record: Record) -> Self {
+      let record_timestamp = record.action().timestamp().as_seconds_and_nanos();
+      let record_datetime = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(record_timestamp.0, record_timestamp.1), Utc);
+
+      Self {
+          record_ah: record.action_hashed().clone().hash,
+          record_datetime,
+      }
+  }
+}
+
+impl IndexableEntry for IndexableRecord {
+  fn entry_time(&self) -> DateTime<Utc> {
+      self.record_datetime
+  }
+
+  fn hash(&self) -> ExternResult<AnyLinkableHash> {
+      Ok(AnyLinkableHash::from(self.record_ah.clone()))
+  }
+}

--- a/dnas/clutter/coordinator_zomes/mews/src/traits.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/traits.rs
@@ -1,0 +1,39 @@
+use std::hash::{Hash, Hasher};
+use hdk::prelude::{Link, AnyLinkableHash};
+use mews_integrity::{FeedMew, MewRanking};
+
+pub struct DedupableLink(pub Link);
+
+impl PartialEq for DedupableLink {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.target == other.0.target
+    }
+}
+
+impl Eq for DedupableLink {}
+
+impl Hash for DedupableLink {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+      self.0.hash(state);
+  }
+}
+
+pub trait Rankable {
+  fn hash(&self, item: FeedMew) -> AnyLinkableHash;
+  fn score(&self, item: FeedMew) -> i64;
+}
+
+impl Rankable for MewRanking {
+  fn hash(&self, item: FeedMew) -> AnyLinkableHash {
+    AnyLinkableHash::from(item.action_hash)
+  }
+
+  fn score(&self, item: FeedMew) -> i64 {
+    match &self {
+      &MewRanking::MostLicks => item.licks.len().try_into().unwrap(),
+      &MewRanking::MostReplies => item.replies.len().try_into().unwrap(),
+      &MewRanking::MostMewmews => item.mewmews.len().try_into().unwrap(),
+      &MewRanking::MostQuotes => item.quotes.len().try_into().unwrap(),
+    }
+  }
+}

--- a/dnas/clutter/coordinator_zomes/mews/src/utils.rs
+++ b/dnas/clutter/coordinator_zomes/mews/src/utils.rs
@@ -1,0 +1,25 @@
+use chrono::{Utc, DateTime, Weekday, TimeZone};
+
+pub fn date_range_year(year: i32) -> (DateTime<Utc>, DateTime<Utc>) {
+  let start = Utc.ymd(year, 1, 1).and_hms(0, 0, 0);
+  let end = Utc.ymd(year, 12, 31).and_hms(23, 59, 59);
+  (start, end)
+}
+
+pub fn date_range_month(year: i32, month: u32) -> (DateTime<Utc>, DateTime<Utc>) {
+  let start = Utc.ymd(year, month, 1).and_hms(0, 0, 0);
+  let end = Utc.ymd(year, month, 31).and_hms(23, 59, 59);
+  (start, end)
+}
+
+pub fn date_range_week(year: i32, iso_week: u32) -> (DateTime<Utc>, DateTime<Utc>) {
+  let start = Utc.isoywd(year, iso_week, Weekday::Mon).and_hms(0, 0, 0);
+  let end = Utc.isoywd(year, iso_week, Weekday::Sun).and_hms(23, 59, 59);
+  (start, end)
+}
+
+pub fn date_range_day(year: i32, ordinal: u32) -> (DateTime<Utc>, DateTime<Utc>) {
+  let start = Utc.yo(year, ordinal).and_hms(0, 0, 0);
+  let end = Utc.yo(year, ordinal).and_hms(23, 59, 59);
+  (start, end)
+}

--- a/dnas/clutter/integrity_zomes/mews/Cargo.toml
+++ b/dnas/clutter/integrity_zomes/mews/Cargo.toml
@@ -9,5 +9,7 @@ name = "mews_integrity"
 
 [dependencies]
 serde = "1"
+strum = "0.24"
+strum_macros = "0.24"
 
 hdi = "=0.1.10"

--- a/dnas/clutter/integrity_zomes/mews/src/lib.rs
+++ b/dnas/clutter/integrity_zomes/mews/src/lib.rs
@@ -70,8 +70,8 @@ pub struct FeedMew {
     pub mewmews: Vec<AnyLinkableHash>,
 }
 
-#[derive(Serialize, Deserialize, SerializedBytes, Debug)]
-pub struct MostLickedMewsRecentlyInput {
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct GetRecentMewsInput {
     pub count: u8,
     pub from_seconds_ago: u32,
 }

--- a/dnas/clutter/integrity_zomes/mews/src/lib.rs
+++ b/dnas/clutter/integrity_zomes/mews/src/lib.rs
@@ -9,6 +9,7 @@ pub enum EntryTypes {
 
 #[hdk_entry_helper]
 #[serde(rename_all = "camelCase")]
+#[derive(Clone)]
 pub enum MewType {
     Original,
     Reply(ActionHash),
@@ -44,6 +45,7 @@ pub struct MewContent {
 
 #[hdk_entry_helper]
 #[serde(rename_all = "camelCase")]
+#[derive(Clone)]
 pub struct Mew {
     pub mew_type: MewType,
     pub content: Option<MewContent>,
@@ -57,6 +59,7 @@ pub struct FeedOptions {
 
 #[hdk_entry_helper]
 #[serde(rename_all = "camelCase")]
+#[derive(Clone)]
 pub struct FeedMew {
     pub mew: Mew,
     pub action: Action,

--- a/dnas/clutter/integrity_zomes/mews/src/lib.rs
+++ b/dnas/clutter/integrity_zomes/mews/src/lib.rs
@@ -3,7 +3,7 @@ use strum_macros::EnumIter;
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
 pub struct DnaProperties {
-    pub ranking_agents_count: usize,
+    pub redundant_rankings_count: usize,
     pub ranking_count: usize,
 }
 

--- a/dnas/clutter/integrity_zomes/mews/src/lib.rs
+++ b/dnas/clutter/integrity_zomes/mews/src/lib.rs
@@ -73,7 +73,7 @@ pub struct FeedMew {
 #[derive(Serialize, Deserialize, SerializedBytes, Debug)]
 pub struct MostLickedMewsRecentlyInput {
     pub count: u8,
-    pub from_hours_ago: u32,
+    pub from_seconds_ago: u32,
 }
 
 #[hdk_link_types]

--- a/dnas/clutter/integrity_zomes/mews/src/lib.rs
+++ b/dnas/clutter/integrity_zomes/mews/src/lib.rs
@@ -1,4 +1,11 @@
 use hdi::prelude::*;
+use strum_macros::EnumIter;
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct DnaProperties {
+    pub ranking_agents_count: usize,
+    pub ranking_count: usize,
+}
 
 #[hdk_entry_defs]
 #[unit_enum(UnitEntryTypes)]
@@ -57,9 +64,8 @@ pub struct FeedOptions {
     pub option: String,
 }
 
-#[hdk_entry_helper]
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-#[derive(Clone)]
 pub struct FeedMew {
     pub mew: Mew,
     pub action: Action,
@@ -76,6 +82,45 @@ pub struct GetRecentMewsInput {
     pub from_seconds_ago: u32,
 }
 
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone, EnumIter)]
+pub enum MewRanking {
+    MostLicks,
+    MostReplies,
+    MostQuotes,
+    MostMewmews,
+}
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct GetRankedMewsByYearInput {
+    pub ranking_type: MewRanking,
+    pub count: u32,
+    pub year: u32,
+}
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct GetRankedMewsByMonthInput {
+    pub ranking_type: MewRanking,
+    pub count: u32,
+    pub year: u32,
+    pub month: u32
+}
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct GetRankedMewsByWeekInput {
+    pub ranking_type: MewRanking,
+    pub count: u32,
+    pub year: u32,
+    pub iso_week: u32
+}
+
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
+pub struct GetRankedMewsByDayInput {
+    pub ranking_type: MewRanking,
+    pub count: u32,
+    pub year: u32,
+    pub ordinal: u32
+}
+
 #[hdk_link_types]
 pub enum LinkTypes {
     Mew,
@@ -87,7 +132,11 @@ pub enum LinkTypes {
     Tag,
     TagPrefix,
     TimeIndexToMew,
-    TimeIndex
+    TimeIndex,
+    RankingIndexMewsMostLicks,
+    RankingIndexMewsMostReplies,
+    RankingIndexMewsMostQuotes,
+    RankingIndexMewsMostMewmews
 }
 
 pub const MEW_PATH_SEGMENT: &str = "mew";
@@ -119,6 +168,32 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             },
             _ => Ok(ValidateCallbackResult::Valid),
         },
+        /* OpType::RegisterCreateLink { target_address, tag, link_type, .. } => match link_type {
+            LinkTypes::RankingIndexMostLicks => {
+                let record = must_get_valid_record(ActionHash::from(target_address))?;
+
+                let _: Mew = record
+                    .entry()
+                    .to_app_option()
+                    .unwrap()
+                    .ok_or(wasm_error!(WasmErrorInner::Guest(String::from("Malformed mew"))))?;
+
+                Ok(ValidateCallbackResult::Valid)
+            }
+            LinkTypes::RankingIndexMostReplies => {
+                
+                Ok(ValidateCallbackResult::Valid)
+            }
+            LinkTypes::RankingIndexMostQuotes => {
+                
+                Ok(ValidateCallbackResult::Valid)
+            }
+            LinkTypes::RankingIndexMostMewmews => {
+                
+                Ok(ValidateCallbackResult::Valid)
+            }
+            _ => Ok(ValidateCallbackResult::Valid),
+        }*/
         _ => Ok(ValidateCallbackResult::Valid),
     }
 }

--- a/dnas/clutter/integrity_zomes/mews/src/lib.rs
+++ b/dnas/clutter/integrity_zomes/mews/src/lib.rs
@@ -70,6 +70,12 @@ pub struct FeedMew {
     pub mewmews: Vec<AnyLinkableHash>,
 }
 
+#[derive(Serialize, Deserialize, SerializedBytes, Debug)]
+pub struct MostLickedMewsRecentlyInput {
+    pub count: u8,
+    pub from_hours_ago: u32,
+}
+
 #[hdk_link_types]
 pub enum LinkTypes {
     Mew,
@@ -80,6 +86,8 @@ pub enum LinkTypes {
     Quote,
     Tag,
     TagPrefix,
+    TimeIndexToMew,
+    TimeIndex
 }
 
 pub const MEW_PATH_SEGMENT: &str = "mew";

--- a/dnas/clutter/workdir/dna.yaml
+++ b/dnas/clutter/workdir/dna.yaml
@@ -7,6 +7,8 @@ integrity:
   properties:
     enforce_spam_limit: 20
     max_chunk_interval: 1000 # 1 second
+    redundant_rankings_count: 3
+    ranking_count: 10
   zomes:
     - name: profiles_integrity
       bundled: ../../../target/wasm32-unknown-unknown/release/profiles_integrity.wasm

--- a/dnas/clutter/workdir/dna.yaml
+++ b/dnas/clutter/workdir/dna.yaml
@@ -4,7 +4,9 @@ name: clutter
 integrity:
   uuid: 00000000-0000-0000-0000-000000000000
   origin_time: 2022-10-05T00:00:00.000000Z
-  properties: ~
+  properties:
+    enforce_spam_limit: 20
+    max_chunk_interval: 86400000 # 1 day
   zomes:
     - name: profiles_integrity
       bundled: ../../../target/wasm32-unknown-unknown/release/profiles_integrity.wasm

--- a/dnas/clutter/workdir/dna.yaml
+++ b/dnas/clutter/workdir/dna.yaml
@@ -6,7 +6,7 @@ integrity:
   origin_time: 2022-10-05T00:00:00.000000Z
   properties:
     enforce_spam_limit: 20
-    max_chunk_interval: 86400000 # 1 day
+    max_chunk_interval: 1000 # 1 second
   zomes:
     - name: profiles_integrity
       bundled: ../../../target/wasm32-unknown-unknown/release/profiles_integrity.wasm

--- a/package-lock.json
+++ b/package-lock.json
@@ -8653,7 +8653,7 @@
         "@quasar/extras": "^1.15.4",
         "@quasar/vite-plugin": "^1.2.3",
         "@vitejs/plugin-vue": "^3.1.2",
-        "dayjs": "*",
+        "dayjs": "^1.11.7",
         "pinia": "^2.0.23",
         "quasar": "^2.9.2",
         "sass": "^1.55.0",

--- a/ui/src/components/MewContent.vue
+++ b/ui/src/components/MewContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="column">
-    <div class="text-body1" style="overflow-wrap: anywhere">
+    <div class="text-body1 text-left" style="overflow-wrap: anywhere">
       <span v-for="(contentPart, index) of contentParts" :key="index">
         <template v-if="Array.isArray(contentPart)">
           <a

--- a/ui/src/components/MewList.vue
+++ b/ui/src/components/MewList.vue
@@ -31,7 +31,7 @@ defineProps({
   },
   onPublishMew: {
     type: Function as PropType<(mewType: MewType) => Promise<void>>,
-    required: true,
+    default: () => Promise.resolve(),
   },
 });
 </script>

--- a/ui/src/components/MewListItem.vue
+++ b/ui/src/components/MewListItem.vue
@@ -56,7 +56,7 @@
         @click="onMewClick"
       />
 
-      <div>
+      <div class="text-left">
         <q-btn
           :disable="isUpdatingLick"
           size="sm"

--- a/ui/src/components/TopMewsList.vue
+++ b/ui/src/components/TopMewsList.vue
@@ -1,0 +1,60 @@
+<template>
+  <q-tabs
+    v-model="tabSelected"
+    narrow-indicator
+    dense
+    align="justify"
+    class="text-primary q-mb-lg m-a-none p-a-none"
+  >
+    <q-tab :ripple="false" name="day" label="Today" />
+    <q-tab :ripple="false" name="week" label="This Week" />
+    <q-tab :ripple="false" name="month" label="This Month" />
+    <q-tab :ripple="false" name="year" label="This Year" />
+  </q-tabs>
+
+  <h6 class="q-mb-sm">Top Licks 👅</h6>
+  <MewList
+    class="q-mb-xl"
+    :mews="store.topMewsList('licks', tabSelected)"
+    :is-loading="store.isLoadingTop['licks']"
+    :on-toggle-lick-mew="onToggleLickMew"
+  />
+  <h6 class="q-mb-sm">Most Replies <q-icon size="sm" name="reply" flat /></h6>
+  <MewList
+    class="q-mb-xl"
+    :mews="store.topMewsList('replies', tabSelected)"
+    :is-loading="store.isLoadingTop['replies']"
+    :on-toggle-lick-mew="onToggleLickMew"
+  />
+
+  <h6 class="q-mb-sm items-center col">
+    Top Mewmews <q-icon size="sm" name="forward" flat />
+  </h6>
+  <MewList
+    class="q-mb-xl"
+    :mews="store.topMewsList('mewmews', tabSelected)"
+    :is-loading="store.isLoadingTop['mewmews']"
+    :on-toggle-lick-mew="onToggleLickMew"
+  />
+
+  <h6 class="q-mb-sm">
+    Top Quotes <q-icon size="sm" name="format_quote" flat />
+  </h6>
+  <MewList
+    class="q-mb-xl"
+    :mews="store.topMewsList('quotes', tabSelected)"
+    :is-loading="store.isLoadingTop['quotes']"
+    :on-toggle-lick-mew="onToggleLickMew"
+  />
+</template>
+<script setup lang="ts">
+import { useClutterStore } from "@/stores";
+import { ref } from "vue";
+import { ActionHash } from "@holochain/client";
+import MewList from "@/components/MewList.vue";
+
+const store = useClutterStore();
+const tabSelected = ref<"day" | "week" | "month" | "year">("week");
+
+const onToggleLickMew = async (hash: ActionHash) => store.reloadMew(hash);
+</script>

--- a/ui/src/pages/HomePage.vue
+++ b/ui/src/pages/HomePage.vue
@@ -55,26 +55,15 @@
 <script setup lang="ts">
 import { pageHeightCorrection } from "@/utils/page-layout";
 import { useClutterStore } from "@/stores";
-import { onMounted, onUpdated, ref } from "vue";
+import { onMounted, ref } from "vue";
 import { ActionHash } from "@holochain/client";
 import MewList from "@/components/MewList.vue";
 
 const store = useClutterStore();
 const tabSelected = ref<string>("this_week");
 
-onMounted(() => {
-  store.fetchMostLickedMewsRecently();
-});
-onUpdated(() => {
-  store.fetchMostLickedMewsRecently();
-});
+onMounted(store.fetchMostLickedMewsRecently);
 
-const onToggleLickMew = async (hash: ActionHash) => {
-  console.log("licked");
-  store.reloadMew(hash);
-};
-const onPublishMew = async () => {
-  console.log("published");
-  store.fetchMostLickedMewsRecently();
-};
+const onToggleLickMew = async (hash: ActionHash) => store.reloadMew(hash);
+const onPublishMew = () => store.fetchMostLickedMewsRecently();
 </script>

--- a/ui/src/pages/HomePage.vue
+++ b/ui/src/pages/HomePage.vue
@@ -1,17 +1,50 @@
 <template>
   <q-page class="text-center" :style-fn="pageHeightCorrection">
     <h6>Meeow, you're in!</h6>
-    <h2>Welcome to the Clutter</h2>
-    <q-img
-      v-if="store.mostLickedMewsFeed?.length === 0"
-      width="40%"
-      src="@/assets/img/cat-eating-bird-circle.png"
-    />
+    <div v-if="store.mostLickedMewsToday?.length === 0">
+      <h2>Welcome to the Clutter</h2>
+      <q-img width="40%" src="@/assets/img/cat-eating-bird-circle.png" />
+    </div>
     <div v-else>
-      <h5 class="q-mb-md">👅 Most Licked Mews 👅</h5>
+      <h5 class="q-mb-xl">Most Licked Mews 👅</h5>
+      <q-tabs
+        v-model="tabSelected"
+        narrow-indicator
+        dense
+        align="justify"
+        class="text-primary q-mb-lg m-a-none p-a-none"
+      >
+        <q-tab :ripple="false" name="today" label="Today" />
+        <q-tab :ripple="false" name="this_week" label="This Week" />
+        <q-tab :ripple="false" name="this_month" label="This Month" />
+        <q-tab :ripple="false" name="this_year" label="This Year" />
+      </q-tabs>
+
       <MewList
-        :mews="store.mostLickedMewsFeed"
-        :is-loading="store.isLoadingMostLickedMewsFeed"
+        v-if="tabSelected === 'today'"
+        :mews="store.mostLickedMewsToday"
+        :is-loading="store.isLoadingMostLickedMewsRecently"
+        :on-toggle-lick-mew="onToggleLickMew"
+        :on-publish-mew="onPublishMew"
+      />
+      <MewList
+        v-else-if="tabSelected === 'this_week'"
+        :mews="store.mostLickedMewsThisWeek"
+        :is-loading="store.isLoadingMostLickedMewsRecently"
+        :on-toggle-lick-mew="onToggleLickMew"
+        :on-publish-mew="onPublishMew"
+      />
+      <MewList
+        v-else-if="tabSelected === 'this_month'"
+        :mews="store.mostLickedMewsThisMonth"
+        :is-loading="store.isLoadingMostLickedMewsRecently"
+        :on-toggle-lick-mew="onToggleLickMew"
+        :on-publish-mew="onPublishMew"
+      />
+      <MewList
+        v-else-if="tabSelected === 'this_year'"
+        :mews="store.mostLickedMewsThisYear"
+        :is-loading="store.isLoadingMostLickedMewsRecently"
         :on-toggle-lick-mew="onToggleLickMew"
         :on-publish-mew="onPublishMew"
       />
@@ -22,15 +55,26 @@
 <script setup lang="ts">
 import { pageHeightCorrection } from "@/utils/page-layout";
 import { useClutterStore } from "@/stores";
-import { onMounted } from "vue";
+import { onMounted, onUpdated, ref } from "vue";
 import { ActionHash } from "@holochain/client";
 import MewList from "@/components/MewList.vue";
 
 const store = useClutterStore();
+const tabSelected = ref<string>("this_week");
+
 onMounted(() => {
-  store.fetchMostLickedMewsFeed(5);
+  store.fetchMostLickedMewsRecently();
+});
+onUpdated(() => {
+  store.fetchMostLickedMewsRecently();
 });
 
-const onToggleLickMew = (hash: ActionHash) => store.reloadMew(hash);
-const onPublishMew = async () => store.fetchMewsFeed();
+const onToggleLickMew = async (hash: ActionHash) => {
+  console.log("licked");
+  store.reloadMew(hash);
+};
+const onPublishMew = async () => {
+  console.log("published");
+  store.fetchMostLickedMewsRecently();
+};
 </script>

--- a/ui/src/pages/HomePage.vue
+++ b/ui/src/pages/HomePage.vue
@@ -1,69 +1,40 @@
 <template>
   <q-page class="text-center" :style-fn="pageHeightCorrection">
-    <h6>Meeow, you're in!</h6>
-    <div v-if="store.mostLickedMewsThisYear?.length === 0">
+    <div v-if="hasTopMewsLists">
+      <h6>Meeow, you're in!</h6>
       <h2>Welcome to the Clutter</h2>
       <q-img width="40%" src="@/assets/img/cat-eating-bird-circle.png" />
     </div>
     <div v-else>
-      <h5 class="q-mb-xl">Most Licked Mews 👅</h5>
-      <q-tabs
-        v-model="tabSelected"
-        narrow-indicator
-        dense
-        align="justify"
-        class="text-primary q-mb-lg m-a-none p-a-none"
-      >
-        <q-tab :ripple="false" name="today" label="Today" />
-        <q-tab :ripple="false" name="this_week" label="This Week" />
-        <q-tab :ripple="false" name="this_month" label="This Month" />
-        <q-tab :ripple="false" name="this_year" label="This Year" />
-      </q-tabs>
-
-      <MewList
-        v-if="tabSelected === 'today'"
-        :mews="store.mostLickedMewsToday"
-        :is-loading="store.isLoadingMostLickedMewsRecently"
-        :on-toggle-lick-mew="onToggleLickMew"
-        :on-publish-mew="onPublishMew"
-      />
-      <MewList
-        v-else-if="tabSelected === 'this_week'"
-        :mews="store.mostLickedMewsThisWeek"
-        :is-loading="store.isLoadingMostLickedMewsRecently"
-        :on-toggle-lick-mew="onToggleLickMew"
-        :on-publish-mew="onPublishMew"
-      />
-      <MewList
-        v-else-if="tabSelected === 'this_month'"
-        :mews="store.mostLickedMewsThisMonth"
-        :is-loading="store.isLoadingMostLickedMewsRecently"
-        :on-toggle-lick-mew="onToggleLickMew"
-        :on-publish-mew="onPublishMew"
-      />
-      <MewList
-        v-else-if="tabSelected === 'this_year'"
-        :mews="store.mostLickedMewsThisYear"
-        :is-loading="store.isLoadingMostLickedMewsRecently"
-        :on-toggle-lick-mew="onToggleLickMew"
-        :on-publish-mew="onPublishMew"
-      />
+      <h6 class="q-mb-none q-mt-none">Meeow, you're in!</h6>
+      <h2 class="q-mt-sm">Welcome to the Clutter</h2>
+      <TopMewsList />
     </div>
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { pageHeightCorrection } from "@/utils/page-layout";
 import { useClutterStore } from "@/stores";
-import { onMounted, ref } from "vue";
-import { ActionHash } from "@holochain/client";
-import MewList from "@/components/MewList.vue";
+import { pageHeightCorrection } from "@/utils/page-layout";
+import { computed, onMounted } from "vue";
+import TopMewsList from "@/components/TopMewsList.vue";
 
 const store = useClutterStore();
-const tabSelected = ref<string>("this_week");
 
-onMounted(store.fetchMostLickedMewsRecently);
+onMounted(() => {
+  store.fetchTopMews("licks");
+  store.fetchTopMews("replies");
+  store.fetchTopMews("mewmews");
+  store.fetchTopMews("quotes");
+});
 
-const onToggleLickMew = async (hash: ActionHash) => store.reloadMew(hash);
-const onPublishMew = () => store.fetchMostLickedMewsRecently();
+const hasTopMewsLists = computed(() => {
+  console.log(store.topMewsAh);
+  return (
+    store.topMewsAh["licks"]["year"]?.length === 0 &&
+    store.topMewsAh["replies"]["year"]?.length === 0 &&
+    store.topMewsAh["mewmews"]["year"]?.length === 0 &&
+    store.topMewsAh["quotes"]["year"]?.length === 0
+  );
+});
 </script>

--- a/ui/src/pages/HomePage.vue
+++ b/ui/src/pages/HomePage.vue
@@ -1,7 +1,7 @@
 <template>
   <q-page class="text-center" :style-fn="pageHeightCorrection">
     <h6>Meeow, you're in!</h6>
-    <div v-if="store.mostLickedMewsToday?.length === 0">
+    <div v-if="store.mostLickedMewsThisYear?.length === 0">
       <h2>Welcome to the Clutter</h2>
       <q-img width="40%" src="@/assets/img/cat-eating-bird-circle.png" />
     </div>

--- a/ui/src/pages/HomePage.vue
+++ b/ui/src/pages/HomePage.vue
@@ -2,10 +2,35 @@
   <q-page class="text-center" :style-fn="pageHeightCorrection">
     <h6>Meeow, you're in!</h6>
     <h2>Welcome to the Clutter</h2>
-    <q-img width="40%" src="@/assets/img/cat-eating-bird-circle.png" />
+    <q-img
+      v-if="store.mostLickedMewsFeed?.length === 0"
+      width="40%"
+      src="@/assets/img/cat-eating-bird-circle.png"
+    />
+    <div v-else>
+      <h5 class="q-mb-md">👅 Most Licked Mews 👅</h5>
+      <MewList
+        :mews="store.mostLickedMewsFeed"
+        :is-loading="store.isLoadingMostLickedMewsFeed"
+        :on-toggle-lick-mew="onToggleLickMew"
+        :on-publish-mew="onPublishMew"
+      />
+    </div>
   </q-page>
 </template>
 
 <script setup lang="ts">
 import { pageHeightCorrection } from "@/utils/page-layout";
+import { useClutterStore } from "@/stores";
+import { onMounted } from "vue";
+import { ActionHash } from "@holochain/client";
+import MewList from "@/components/MewList.vue";
+
+const store = useClutterStore();
+onMounted(() => {
+  store.fetchMostLickedMewsFeed(5);
+});
+
+const onToggleLickMew = (hash: ActionHash) => store.reloadMew(hash);
+const onPublishMew = async () => store.fetchMewsFeed();
 </script>

--- a/ui/src/services/clutter-dna.ts
+++ b/ui/src/services/clutter-dna.ts
@@ -9,6 +9,7 @@ export enum MewsFn {
   CreateMew = "create_mew",
   GetMew = "get_mew",
   MewsFeed = "mews_feed",
+  MostLickedMewsFeed = "most_licked_mews_feed",
   MewsBy = "mews_by",
   Follow = "follow",
   Followers = "followers",
@@ -48,6 +49,10 @@ export const getMew = async (mew: ActionHash): Promise<Mew> =>
 
 export const mewsFeed = async (options: FeedOptions): Promise<Array<FeedMew>> =>
   callZome(MewsFn.MewsFeed, options);
+
+export const mostLickedMewsFeed = async (
+  count: number
+): Promise<Array<FeedMew>> => callZome(MewsFn.MostLickedMewsFeed, count);
 
 export const mewsBy = async (
   agent: AgentPubKey | AgentPubKeyB64

--- a/ui/src/services/clutter-dna.ts
+++ b/ui/src/services/clutter-dna.ts
@@ -7,16 +7,20 @@ import {
   CreateMewInput,
   FeedMew,
   FeedOptions,
+  GetRecentMewsInput,
   Mew,
-  MostLickedMewsOptions,
+  TopMewsInteractions,
 } from "../types/types";
 
 export enum MewsFn {
   CreateMew = "create_mew",
   GetMew = "get_mew",
   MewsFeed = "mews_feed",
-  MostLickedMewsRecently = "most_licked_mews_recently",
   MewsBy = "mews_by",
+  MewsMostLicked = "mews_most_licked",
+  MewsMostMewmewed = "mews_most_mewmewed",
+  MewsMostReplied = "mews_most_replied",
+  MewsMostQuoted = "mews_most_quoted",
   Follow = "follow",
   Followers = "followers",
   Following = "following",
@@ -56,10 +60,6 @@ export const getMew = async (mew: ActionHash): Promise<Mew> =>
 export const mewsFeed = async (options: FeedOptions): Promise<Array<FeedMew>> =>
   callZome(MewsFn.MewsFeed, options);
 
-export const mostLickedMewsRecently = async (
-  options: MostLickedMewsOptions
-): Promise<Array<FeedMew>> => callZome(MewsFn.MostLickedMewsRecently, options);
-
 export const mewsBy = async (
   agent: AgentPubKey | AgentPubKeyB64
 ): Promise<Array<FeedMew>> =>
@@ -67,6 +67,23 @@ export const mewsBy = async (
     MewsFn.MewsBy,
     typeof agent === "string" ? deserializeHash(agent) : agent
   );
+
+export const mewsTopList = async (
+  interaction: TopMewsInteractions,
+  options: GetRecentMewsInput
+): Promise<Array<FeedMew>> => {
+  if (interaction === "licks") {
+    return callZome(MewsFn.MewsMostLicked, options);
+  } else if (interaction === "mewmews") {
+    return callZome(MewsFn.MewsMostMewmewed, options);
+  } else if (interaction === "quotes") {
+    return callZome(MewsFn.MewsMostQuoted, options);
+  } else if (interaction === "replies") {
+    return callZome(MewsFn.MewsMostReplied, options);
+  } else {
+    throw Error("Interaction type must be defined");
+  }
+};
 
 export const follow = async (agent: AgentPubKey): Promise<null> =>
   callZome(MewsFn.Follow, agent);

--- a/ui/src/services/clutter-dna.ts
+++ b/ui/src/services/clutter-dna.ts
@@ -3,13 +3,19 @@ import { CLUTTER_ROLE_NAME, MEWS_ZOME_NAME } from "@/stores/clutter";
 import { AgentPubKeyB64 } from "@holochain-open-dev/core-types";
 import { deserializeHash } from "@holochain-open-dev/utils";
 import { ActionHash, AgentPubKey, CallZomeRequest } from "@holochain/client";
-import { CreateMewInput, FeedMew, FeedOptions, Mew } from "../types/types";
+import {
+  CreateMewInput,
+  FeedMew,
+  FeedOptions,
+  Mew,
+  MostLickedMewsOptions,
+} from "../types/types";
 
 export enum MewsFn {
   CreateMew = "create_mew",
   GetMew = "get_mew",
   MewsFeed = "mews_feed",
-  MostLickedMewsFeed = "most_licked_mews_feed",
+  MostLickedMewsRecently = "most_licked_mews_recently",
   MewsBy = "mews_by",
   Follow = "follow",
   Followers = "followers",
@@ -50,9 +56,9 @@ export const getMew = async (mew: ActionHash): Promise<Mew> =>
 export const mewsFeed = async (options: FeedOptions): Promise<Array<FeedMew>> =>
   callZome(MewsFn.MewsFeed, options);
 
-export const mostLickedMewsFeed = async (
-  count: number
-): Promise<Array<FeedMew>> => callZome(MewsFn.MostLickedMewsFeed, count);
+export const mostLickedMewsRecently = async (
+  options: MostLickedMewsOptions
+): Promise<Array<FeedMew>> => callZome(MewsFn.MostLickedMewsRecently, options);
 
 export const mewsBy = async (
   agent: AgentPubKey | AgentPubKeyB64

--- a/ui/src/stores/clutter.ts
+++ b/ui/src/stores/clutter.ts
@@ -3,7 +3,7 @@ import {
   getFeedMewAndContext,
   mewsFeed,
   MewsFn,
-  mostLickedMewsFeed,
+  mostLickedMewsRecently,
 } from "@/services/clutter-dna";
 import { CreateMewInput, FeedMew } from "@/types/types";
 import { isSameHash } from "@/utils/hash";
@@ -18,9 +18,12 @@ export const makeUseClutterStore = () => {
   return defineStore("clutter", {
     state: () => ({
       mewsFeed: [] as FeedMew[],
-      mostLickedMewsFeed: [] as FeedMew[],
+      mostLickedMewsToday: [] as FeedMew[],
+      mostLickedMewsThisWeek: [] as FeedMew[],
+      mostLickedMewsThisMonth: [] as FeedMew[],
+      mostLickedMewsThisYear: [] as FeedMew[],
       isLoadingMewsFeed: false,
-      isLoadingMostLickedMewsFeed: false,
+      isLoadingMostLickedMewsRecently: false,
     }),
     actions: {
       async fetchMewsFeed() {
@@ -33,14 +36,36 @@ export const makeUseClutterStore = () => {
           this.isLoadingMewsFeed = false;
         }
       },
-      async fetchMostLickedMewsFeed(count: number) {
+      async fetchMostLickedMewsRecently() {
         try {
-          this.isLoadingMostLickedMewsFeed = true;
-          this.mostLickedMewsFeed = await mostLickedMewsFeed(count);
+          this.isLoadingMostLickedMewsRecently = true;
+          [
+            this.mostLickedMewsToday,
+            this.mostLickedMewsThisWeek,
+            this.mostLickedMewsThisMonth,
+            this.mostLickedMewsThisYear,
+          ] = await Promise.all([
+            mostLickedMewsRecently({
+              count: 5,
+              from_hours_ago: 24,
+            }),
+            mostLickedMewsRecently({
+              count: 5,
+              from_hours_ago: 24 * 7,
+            }),
+            mostLickedMewsRecently({
+              count: 5,
+              from_hours_ago: 24 * 31,
+            }),
+            mostLickedMewsRecently({
+              count: 5,
+              from_hours_ago: 24 * 365,
+            }),
+          ]);
         } catch (error) {
           showError(error);
         } finally {
-          this.isLoadingMostLickedMewsFeed = false;
+          this.isLoadingMostLickedMewsRecently = false;
         }
       },
       async reloadMew(actionHash: ActionHash) {

--- a/ui/src/stores/clutter.ts
+++ b/ui/src/stores/clutter.ts
@@ -3,6 +3,7 @@ import {
   getFeedMewAndContext,
   mewsFeed,
   MewsFn,
+  mostLickedMewsFeed,
 } from "@/services/clutter-dna";
 import { CreateMewInput, FeedMew } from "@/types/types";
 import { isSameHash } from "@/utils/hash";
@@ -17,7 +18,9 @@ export const makeUseClutterStore = () => {
   return defineStore("clutter", {
     state: () => ({
       mewsFeed: [] as FeedMew[],
+      mostLickedMewsFeed: [] as FeedMew[],
       isLoadingMewsFeed: false,
+      isLoadingMostLickedMewsFeed: false,
     }),
     actions: {
       async fetchMewsFeed() {
@@ -28,6 +31,16 @@ export const makeUseClutterStore = () => {
           showError(error);
         } finally {
           this.isLoadingMewsFeed = false;
+        }
+      },
+      async fetchMostLickedMewsFeed(count: number) {
+        try {
+          this.isLoadingMostLickedMewsFeed = true;
+          this.mostLickedMewsFeed = await mostLickedMewsFeed(count);
+        } catch (error) {
+          showError(error);
+        } finally {
+          this.isLoadingMostLickedMewsFeed = false;
         }
       },
       async reloadMew(actionHash: ActionHash) {

--- a/ui/src/stores/clutter.ts
+++ b/ui/src/stores/clutter.ts
@@ -54,19 +54,19 @@ export const makeUseClutterStore = () => {
           ] = await Promise.all([
             mostLickedMewsRecently({
               count: 5,
-              from_hours_ago: 24,
+              from_seconds_ago: 24 * 60 * 60,
             }),
             mostLickedMewsRecently({
               count: 5,
-              from_hours_ago: 24 * 7,
+              from_seconds_ago: 24 * 60 * 60 * 7,
             }),
             mostLickedMewsRecently({
               count: 5,
-              from_hours_ago: 24 * 31,
+              from_seconds_ago: 24 * 60 * 60 * 31,
             }),
             mostLickedMewsRecently({
               count: 5,
-              from_hours_ago: 24 * 365,
+              from_seconds_ago: 24 * 60 * 60 * 365,
             }),
           ]);
           mostLickedMewsToday.forEach((feedMew) => {

--- a/ui/src/types/types.ts
+++ b/ui/src/types/types.ts
@@ -77,6 +77,40 @@ export interface GetRecentMewsInput {
   from_seconds_ago: number;
 }
 
+export enum MewRanking {
+  MostLicks,
+  MostReplies,
+  MostQuotes,
+  MostMewmews,
+}
+
+export interface GetRankedMewsByYearInput {
+  ranking_type: MewRanking;
+  count: number;
+  year: number;
+}
+
+export interface GetRankedMewsByMonthInput {
+  ranking_type: MewRanking;
+  count: number;
+  year: number;
+  month: number;
+}
+
+export interface GetRankedMewsByWeekInput {
+  ranking_type: MewRanking;
+  count: number;
+  year: number;
+  iso_week: number;
+}
+
+export interface GetRankedMewsByDayInput {
+  ranking_link_type: MewRanking;
+  count: number;
+  year: number;
+  ordinal: number;
+}
+
 export interface NotificationOptions {
   color?: string;
   textColor?: string;

--- a/ui/src/types/types.ts
+++ b/ui/src/types/types.ts
@@ -74,7 +74,7 @@ export interface FeedOptions {
 
 export interface MostLickedMewsOptions {
   count: number;
-  from_hours_ago: number;
+  from_seconds_ago: number;
 }
 
 export interface NotificationOptions {

--- a/ui/src/types/types.ts
+++ b/ui/src/types/types.ts
@@ -72,6 +72,11 @@ export interface FeedOptions {
   option: string;
 }
 
+export interface MostLickedMewsOptions {
+  count: number;
+  from_hours_ago: number;
+}
+
 export interface NotificationOptions {
   color?: string;
   textColor?: string;

--- a/ui/src/types/types.ts
+++ b/ui/src/types/types.ts
@@ -72,7 +72,7 @@ export interface FeedOptions {
   option: string;
 }
 
-export interface MostLickedMewsOptions {
+export interface GetRecentMewsInput {
   count: number;
   from_seconds_ago: number;
 }
@@ -103,3 +103,6 @@ export enum SearchResult {
   Hashtag,
   Cashtag,
 }
+
+export type TopMewsInteractions = "licks" | "mewmews" | "replies" | "quotes";
+export type TopMewsTimespans = "day" | "week" | "month" | "year";


### PR DESCRIPTION
Iterates on #46, attempting to make a global ranking of Mews feasible.

**overview**
- adds dependency: https://github.com/holochain-open-dev/ranking-index (temporarily on forked version for hc 175 support)
- adds dependencies: strum, strum_macros
- adds dna properties: `redundant_rankings_count` and `ranking_count` 
- adds a scheduled function that runs daily:
  - checks if `redundant_rankings_count` ranking indices have been created already. If not, generates a new ranking index.
- adds an hdk extern function for querying rankings
  - gets *all* redundant ranking indexes
  - deduplicates them
  - re-sorts
  - takes top `ranking_count` items
 
I thought this might be a nice compromise between a full "consensus" architecture for global rankings, and a fully decentralized architecture where every agent generates their own rankings. The trust model is:
  - Inclusion of mews in rankings list: 1/N (where N is the number of agents generating ranking indices for a round)
  - Sorting of rankings list: 0/N (every agent performs their own sorting and top X selection from the aggregated rankings lists)