### PR TITLE
build: add CACHIX_AUTH_TOKEN secret to github test actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Set up cachix
         uses: cachix/cachix-action@v12
         with:
-          name: holochain-ci
+          name: geekgene
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Cache Cargo and Rust Build
         uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           name: geekgene
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          pathsToPush:
 
       - name: Cache Cargo and Rust Build
         uses: actions/cache@v2


### PR DESCRIPTION
On @harlantwood 's recommendation, this PR adds write-permissions to our cachix instance for CI.

- I setup a new cachix account on the free tier just for mewsfeed. 
- I added the cachix account auth token to our github repo secrets.
- This PR just modifies the github action spec to use that cachix account and auth token.

Hopefully this will reduce the CI time by reducing the time to build and setup the nix environment.