### PR TITLE
ci(test): run on push to develop to improve caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - "develop"
       - "main"
 
 concurrency:


### PR DESCRIPTION
I notice that new PRs are not making use of the cached builds from other PRs. That's a [Github conundrum](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).

This PR enables pipeline runs on pushing to `develop`, because all branches/PRs have access to its cache and `develop` is the branch where PRs usually are merged into.