### PR TITLE
Refactor link input ux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
       },
       "locked": {
         "dir": "versions/0_1",
-        "lastModified": 1680895032,
-        "narHash": "sha256-AFl7Uby9p5XpQN3B+GtWwxCtIFVYEi+stQVRp+naRw4=",
+        "lastModified": 1680934732,
+        "narHash": "sha256-toWVNDyl05izqGM63b9viVgzgbRP53B5v2KBX37yUdQ=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "9e6f99598ae730ba77a448f0d8781dda17098aaa",
+        "rev": "6b351dde72eee2ad846d34b53a288d526ce8026d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
       },
       "locked": {
         "dir": "versions/0_1",
-        "lastModified": 1680224687,
-        "narHash": "sha256-XcQKvmhNxEekuLPn0vDDPVoFKnogWcYIn07X7JFN4Hs=",
+        "lastModified": 1680330029,
+        "narHash": "sha256-5XjozxS08u8S5b7whCuwz4bwt0MofWg1E8wBcVcMRsU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "5cabf5018bcd1f0284f88f5acf31de70ae8ce113",
+        "rev": "aa895c40787ce4caad52e3cfed0972fcdeffb7fc",
         "type": "github"
       },
       "original": {

--- a/ui/src/components/CreateMewField.vue
+++ b/ui/src/components/CreateMewField.vue
@@ -38,7 +38,7 @@
           placeholder="Paste a URL to create a link"
           dense
           borderless
-          :rules="[(val: string) => (val?.length === 0 || isRawUrl(val)) || 'Link target must be valid URL']"
+          :rules="[(val: string) => isRawUrl(val) || 'Link target must be valid URL']"
           @keydown.enter="createLinkTag"
           @keydown.space="createLinkTag"
           @keydown.tab="createLinkTag"

--- a/ui/src/components/MewContent.vue
+++ b/ui/src/components/MewContent.vue
@@ -45,7 +45,7 @@ const contentParts = computed<ContentPart[]>(() =>
   parts.value.map((part) => {
     if (isTag(part)) {
       let agentPubKey: string | undefined = undefined;
-      if (part[0] === TAG_SYMBOLS.MENTION || part[0] === TAG_SYMBOLS.URL) {
+      if (part[0] === TAG_SYMBOLS.MENTION || part[0] === TAG_SYMBOLS.LINK) {
         const link = links.value?.pop();
         if (!link) {
           return part;

--- a/ui/src/utils/tags.ts
+++ b/ui/src/utils/tags.ts
@@ -15,7 +15,6 @@ const regexpString = [
   `\\B\\${TAG_SYMBOLS.CASHTAG}\\w+`,
   `\\B\\${TAG_SYMBOLS.HASHTAG}\\w+`,
   MENTION_TAG_REGEX.source,
-  `\\B\\${TAG_SYMBOLS.LINK}\\[[\\S ]+\\]`, // multi-word labeled url
   LINK_TAG_REGEX.source, // single-word labeled url
 ];
 

--- a/ui/src/utils/tags.ts
+++ b/ui/src/utils/tags.ts
@@ -2,18 +2,21 @@ export const TAG_SYMBOLS = {
   CASHTAG: "$",
   HASHTAG: "#",
   MENTION: "@",
-  URL: "^",
+  LINK: "^",
 };
 
 const MENTION_TAG_REGEX_STRING = `\\B\\${TAG_SYMBOLS.MENTION}\\S+`;
 const MENTION_TAG_REGEX = new RegExp(MENTION_TAG_REGEX_STRING, "mi");
 
+const LINK_TAG_REGEX_STRING = `\\B\\${TAG_SYMBOLS.LINK}\\S+`;
+const LINK_TAG_REGEX = new RegExp(LINK_TAG_REGEX_STRING, "mi");
+
 const regexpString = [
   `\\B\\${TAG_SYMBOLS.CASHTAG}\\w+`,
   `\\B\\${TAG_SYMBOLS.HASHTAG}\\w+`,
   MENTION_TAG_REGEX.source,
-  `\\B\\${TAG_SYMBOLS.URL}\\[[\\S ]+\\]`, // multi-word labeled url
-  `\\B\\${TAG_SYMBOLS.URL}\\S+`, // single-word labeled url
+  `\\B\\${TAG_SYMBOLS.LINK}\\[[\\S ]+\\]`, // multi-word labeled url
+  LINK_TAG_REGEX.source, // single-word labeled url
 ];
 
 const TAG_REGEX = new RegExp(`${regexpString.join("|")}`, "mi");
@@ -30,6 +33,8 @@ export const isTag = (text: string): boolean => TAG_REGEX.test(text);
 
 export const isMentionTag = (text: string): boolean =>
   MENTION_TAG_REGEX.test(text);
+
+export const isLinkTag = (text: string): boolean => LINK_TAG_REGEX.test(text);
 
 export const isRawUrl = (text: string): boolean => RAW_URL_REGEX.test(text);
 


### PR DESCRIPTION
Resolves #97 

**Overview**
- In CreateMew field, upon entering `^label`, an input field pops up, where the user must enter a valid URL. That URL becomes the target for the link labelled by `^label`
- Remove multi-word url label support entirely. It adds a bunch of work the refactor for little clear UX improvement. Additionally, since #hashtags and $cashtags can only be a single word, it seems consistent that ^links should only be a single word as well.
- Some minor refactoring and reorganization of the CreateMewField component for readability