### PR TITLE
ci(test): replace cache by restore and save

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,8 @@ jobs:
         with:
           name: holochain-ci
 
-      - name: Cache Cargo and Rust Build
-        uses: actions/cache@v2
-        if: always()  # build artifacts are correct even if job fails
+      - name: Restore cargo and build from cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             .cargo
@@ -50,6 +49,14 @@ jobs:
 
       - name: Build Happ
         run: nix develop -c $SHELL -c "npm run build:happ"
+
+      - name: Save cargo and build to cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            .cargo
+            target
+          key: ${{ runner.os }}-build-${{ hashFiles('Cargo.lock') }}
 
       - name: Test with tryorama
         run: nix develop -c $SHELL -c "npm test"


### PR DESCRIPTION
Caching only works if the previous jobs were successful (https://github.com/actions/cache/blob/826785142ab6c0b7ce4ad2eadf642c6351ca6483/action.yml#L21)

This replaces the cache action by separate restore and save actions, so that build are always saved when successful, regardless of tests.