### PR TITLE
Fix/link tag input render

### DIFF
--- a/ui/src/components/CreateMewInput.vue
+++ b/ui/src/components/CreateMewInput.vue
@@ -370,12 +370,12 @@ const createLinkTag = (e: Event) => {
   range.insertNode(anchor);
 
   // insert space after html link
-  const spaceNode = document.createTextNode(String.fromCharCode(160));
+  const spaceNode = document.createTextNode("");
   anchor.after(spaceNode);
 
   // reset input
   resetLinkTargetInput();
-  document.getSelection()?.setPosition(spaceNode, 1);
+  document.getSelection()?.setPosition(spaceNode, 0);
 };
 
 /**

--- a/ui/src/components/CreateMewInput.vue
+++ b/ui/src/components/CreateMewInput.vue
@@ -579,12 +579,24 @@ const onCaretPositionChange = () => {
       }
       // current word is a URL
     } else if (isLinkTag(currentWord)) {
+
+      // find start of tag that the caret is positioned at
+      const behind = content.substring(0, selection.anchorOffset - 1);
+      let lastCaretIndex = -1;
+      // find last index of space, which can be " " (32) or "&nbsp;" (160)
+      for (let i = behind.length - 1; i >= 0; i--) {
+        if (behind.charCodeAt(i) === 94) {
+          lastCaretIndex = i;
+          break;
+        }
+      }
+
       showElement(
         selection.anchorNode,
-        startOfWordIndex,
+        lastCaretIndex,
         "#link-target-input-container"
       );
-      currentAnchorOffset = startOfWordIndex;
+      currentAnchorOffset = lastCaretIndex;
       currentFocusOffset = endOfWordIndex;
     } else {
       hideAutocompleter();

--- a/ui/src/utils/tags.ts
+++ b/ui/src/utils/tags.ts
@@ -1,15 +1,3 @@
-import { ROUTES } from "@/router";
-import {
-  LinkTarget,
-  LinkTargetName,
-  MentionLinkTarget,
-  MewContentPart,
-  MewTagType,
-  UrlLinkTarget,
-} from "@/types/types";
-import { AgentPubKey, encodeHashToBase64 } from "@holochain/client";
-import { RouteLocationRaw } from "vue-router";
-
 export const TAG_SYMBOLS = {
   CASHTAG: "$",
   HASHTAG: "#",
@@ -20,7 +8,7 @@ export const TAG_SYMBOLS = {
 const MENTION_TAG_REGEX_STRING = `\\B\\${TAG_SYMBOLS.MENTION}\\S+`;
 const MENTION_TAG_REGEX = new RegExp(MENTION_TAG_REGEX_STRING, "mi");
 
-const LINK_TAG_REGEX_STRING = `\\B\\${TAG_SYMBOLS.LINK}\\S+`;
+const LINK_TAG_REGEX_STRING = `\\B\\${TAG_SYMBOLS.LINK}\\w+`;
 const LINK_TAG_REGEX = new RegExp(LINK_TAG_REGEX_STRING, "mi");
 
 const CASH_TAG_REGEX_STRING = `\\B\\${TAG_SYMBOLS.CASHTAG}\\w+`;


### PR DESCRIPTION
Partially resolves #172 

Resolves some of the low-hanging issues with creating /rendering link tags, without doing #120.

- No longer insert a space after a link tag (in the mew input field)
- No longer highlight text before the `^` in the mew input field when creating a link tag
- No longer include special characters in rendered link tags, except for `_`

This does not resolve the issue where the link tag in the input field is improperly highlighted if the link tag includes disallowed characters. i.e. A link tag `^my+link+tag` will appear highlighted in the input field, even though only `^my` will be rendered as a link in the mew.