### PR TITLE
Only show errors toasts for active user actions

### DIFF
--- a/ui/src/components/CreatorsListDialog.vue
+++ b/ui/src/components/CreatorsListDialog.vue
@@ -44,7 +44,6 @@ import BaseAgentProfileListItemSkeleton from "@/components/BaseAgentProfileListI
 import BaseEmptyList from "@/components/BaseEmptyList.vue";
 import BaseAgentProfileList from "@/components/BaseAgentProfileList.vue";
 import { watch } from "vue";
-import { useToasts } from "@/stores/toasts";
 import { ProfilesStore } from "@holochain-open-dev/profiles";
 import { encodeHashToBase64 } from "@holochain/client";
 import { AgentProfile } from "@/types/types";

--- a/ui/src/components/CreatorsListDialog.vue
+++ b/ui/src/components/CreatorsListDialog.vue
@@ -61,7 +61,6 @@ const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const profilesStore = (inject("profilesStore") as ComputedRef<ProfilesStore>)
   .value;
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 
 const pageLimit = 10;
 
@@ -119,7 +118,7 @@ const fetchNextPageInfiniteScroll = async (
   done(hasNextPage?.value);
 };
 
-watch(error, showError);
+watch(error, console.error);
 
 onBeforeRouteLeave(() => {
   if (data.value && data.value.pages.length > 1) {

--- a/ui/src/components/FollowersListDialog.vue
+++ b/ui/src/components/FollowersListDialog.vue
@@ -44,7 +44,6 @@ import BaseAgentProfileListItemSkeleton from "@/components/BaseAgentProfileListI
 import BaseEmptyList from "@/components/BaseEmptyList.vue";
 import BaseAgentProfileList from "@/components/BaseAgentProfileList.vue";
 import { watch } from "vue";
-import { useToasts } from "@/stores/toasts";
 import { ProfilesStore } from "@holochain-open-dev/profiles";
 import { encodeHashToBase64 } from "@holochain/client";
 import { AgentProfile } from "@/types/types";

--- a/ui/src/components/FollowersListDialog.vue
+++ b/ui/src/components/FollowersListDialog.vue
@@ -61,7 +61,6 @@ const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const profilesStore = (inject("profilesStore") as ComputedRef<ProfilesStore>)
   .value;
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 
 const pageLimit = 10;
 
@@ -119,7 +118,7 @@ const fetchNextPageInfiniteScroll = async (
   done(hasNextPage?.value);
 };
 
-watch(error, showError);
+watch(error, console.error);
 
 onBeforeRouteLeave(() => {
   if (data.value && data.value.pages.length > 1) {

--- a/ui/src/pages/AgentProfile.vue
+++ b/ui/src/pages/AgentProfile.vue
@@ -156,7 +156,6 @@ const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const route = useRoute();
 const router = useRouter();
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 
 const agentPubKey = computed(() =>
   decodeHashFromBase64(route.params.agentPubKey as string)
@@ -193,7 +192,7 @@ const {
   ],
   queryFn: fetchAuthoredMews,
 });
-watch(errorAuthoredMews, showError);
+watch(errorAuthoredMews, console.error);
 
 const fetchPinnedMews = () =>
   client.callZome({
@@ -216,7 +215,7 @@ const {
   ],
   queryFn: fetchPinnedMews,
 });
-watch(errorPinnedMews, showError);
+watch(errorPinnedMews, console.error);
 
 const fetchProfileWithContext = async () => {
   const profile = await profilesStore.client.getAgentProfile(agentPubKey.value);
@@ -250,7 +249,7 @@ const {
   ],
   queryFn: fetchProfileWithContext,
 });
-watch(errorProfile, showError);
+watch(errorProfile, console.error);
 
 const fetchFollowers = async () => {
   const agents: AgentPubKey[] = await client.callZome({
@@ -288,7 +287,7 @@ const { data: followers, error: errorFollowers } = useQuery({
   ],
   queryFn: fetchFollowers,
 });
-watch(errorFollowers, showError);
+watch(errorFollowers, console.error);
 
 const fetchCreators = async () => {
   const agents: AgentPubKey[] = await client.callZome({
@@ -326,7 +325,7 @@ const { data: creators, error: errorCreators } = useQuery({
   ],
   queryFn: fetchCreators,
 });
-watch(errorCreators, showError);
+watch(errorCreators, console.error);
 
 const fetchCreatorsCount = async (): Promise<number> =>
   client.callZome({
@@ -344,7 +343,7 @@ const { data: creatorsCount, error: errorCreatorsCount } = useQuery({
   ],
   queryFn: fetchCreatorsCount,
 });
-watch(errorCreatorsCount, showError);
+watch(errorCreatorsCount, console.error);
 
 const fetchFollowersCount = async (): Promise<number> =>
   client.callZome({
@@ -366,5 +365,5 @@ const {
   ],
   queryFn: fetchFollowersCount,
 });
-watch(errorFollowersCount, showError);
+watch(errorFollowersCount, console.error);
 </script>

--- a/ui/src/pages/AgentProfile.vue
+++ b/ui/src/pages/AgentProfile.vue
@@ -133,7 +133,6 @@
 
 <script setup lang="ts">
 import { AgentProfile } from "@/types/types";
-import { useToasts } from "@/stores/toasts";
 import {
   AgentPubKey,
   decodeHashFromBase64,

--- a/ui/src/pages/DiscoverCreators.vue
+++ b/ui/src/pages/DiscoverCreators.vue
@@ -141,7 +141,6 @@ import BaseListSkeleton from "@/components/BaseListSkeleton.vue";
 import BaseMewListItemSkeleton from "@/components/BaseMewListItemSkeleton.vue";
 
 const client = (inject("client") as ComputedRef<AppAgentClient>).value;
-const { showError } = useToasts();
 
 const fetchRandomMewHashes = (): Promise<ActionHash[]> =>
   client.callZome({
@@ -171,7 +170,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomMewHashes, showError);
+watch(errorRandomMewHashes, console.error);
 
 const hasRandomMewHashes = computed(
   () => randomMewHashes.value !== undefined && randomMewHashes.value.length > 0
@@ -191,7 +190,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomMews, showError);
+watch(errorRandomMews, console.error);
 
 const fetchRandomTags = (): Promise<string[]> => {
   return client.callZome({
@@ -214,7 +213,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomTags, showError);
+watch(errorRandomTags, console.error);
 
 onMounted(async () => {
   if (randomMews.value === undefined || randomMews.value.length === 0) {
@@ -270,7 +269,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomMewHashesWithTag1, showError);
+watch(errorRandomMewHashesWithTag1, console.error);
 const hasRandomMewHashesWithTag1 = computed(
   () =>
     tag1Enabled.value &&
@@ -298,7 +297,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomMewsWithTag1, showError);
+watch(errorRandomMewsWithTag1, console.error);
 
 // Random Mews with Tag 2
 
@@ -315,7 +314,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomMewHashesWithTag2, showError);
+watch(errorRandomMewHashesWithTag2, console.error);
 const hasRandomMewHashesWithTag2 = computed(
   () =>
     tag2Enabled.value &&
@@ -343,7 +342,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomMewsWithTag2, showError);
+watch(errorRandomMewsWithTag2, console.error);
 
 // Random Mews with Tag 3
 
@@ -360,7 +359,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomMewHashesWithTag3, showError);
+watch(errorRandomMewHashesWithTag3, console.error);
 const hasRandomMewHashesWithTag3 = computed(
   () =>
     tag3Enabled.value &&
@@ -388,7 +387,7 @@ const {
   refetchOnMount: false,
   refetchOnReconnect: false,
 });
-watch(errorRandomMewsWithTag3, showError);
+watch(errorRandomMewsWithTag3, console.error);
 
 const shuffle = async () => {
   await refetchMews();

--- a/ui/src/pages/DiscoverCreators.vue
+++ b/ui/src/pages/DiscoverCreators.vue
@@ -134,7 +134,6 @@ import { AppAgentClient } from "@holochain/client";
 import BaseList from "@/components/BaseList.vue";
 import { FeedMew } from "@/types/types";
 import { useQuery } from "@tanstack/vue-query";
-import { useToasts } from "@/stores/toasts";
 import IconDiceOutline from "~icons/ion/dice-outline";
 import { ActionHash } from "@holochain/client";
 import BaseListSkeleton from "@/components/BaseListSkeleton.vue";

--- a/ui/src/pages/MewYarn.vue
+++ b/ui/src/pages/MewYarn.vue
@@ -62,7 +62,6 @@ import { decodeHashFromBase64 } from "@holochain/client";
 import { ComputedRef, computed, inject, watch } from "vue";
 import { useRoute, onBeforeRouteLeave } from "vue-router";
 import { AppAgentClient } from "@holochain/client";
-import { useToasts } from "@/stores/toasts";
 import {
   useInfiniteQuery,
   useQuery,
@@ -162,7 +161,6 @@ const refetchRepliesPage = async (pageIndex: number) => {
     refetchPage: (page: any, index: number) => index === pageIndex,
   });
 };
-
 
 onBeforeRouteLeave(() => {
   if (replies.value && replies.value.pages.length > 1) {

--- a/ui/src/pages/MewYarn.vue
+++ b/ui/src/pages/MewYarn.vue
@@ -75,7 +75,6 @@ import BaseInfiniteScroll from "@/components/BaseInfiniteScroll.vue";
 const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const route = useRoute();
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 
 const pageLimit = 10;
 
@@ -103,7 +102,7 @@ const {
   enabled: hasActionHash,
   refetchInterval: 1000 * 60 * 2, // 2 minutes
 });
-watch(mewError, showError);
+watch(mewError, console.error);
 
 const fetchReplies = (params: any) =>
   client.callZome({
@@ -146,7 +145,7 @@ const {
   refetchInterval: 1000 * 60 * 2, // 2 minutes
   refetchOnMount: true,
 });
-watch(errorReplies, showError);
+watch(errorReplies, console.error);
 
 const fetchNextPageReplies = async (done: (hasMore?: boolean) => void) => {
   await fetchNextPage();

--- a/ui/src/pages/MewsFeed.vue
+++ b/ui/src/pages/MewsFeed.vue
@@ -68,7 +68,6 @@ import { onBeforeRouteLeave } from "vue-router";
 
 const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 const pageLimit = 10;
 
 const fetchMewsFeed = (params: any): Promise<FeedMew[]> =>
@@ -103,7 +102,7 @@ const { data, error, fetchNextPage, hasNextPage, isInitialLoading, refetch } =
     refetchInterval: 1000 * 60 * 2, // 2 minutes
     refetchOnMount: true,
   });
-watch(error, showError);
+watch(error, console.error);
 
 const fetchNextPageInfiniteScroll = async (
   done: (hasMore?: boolean) => void

--- a/ui/src/pages/MewsFeed.vue
+++ b/ui/src/pages/MewsFeed.vue
@@ -58,7 +58,6 @@ import { AppAgentClient, encodeHashToBase64 } from "@holochain/client";
 import { ComputedRef, inject, watch } from "vue";
 import { FeedMew, PaginationDirectionName } from "@/types/types";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/vue-query";
-import { useToasts } from "@/stores/toasts";
 import BaseMewListItem from "@/components/BaseMewListItem.vue";
 import BaseEmptyList from "@/components/BaseEmptyList.vue";
 import BaseListSkeleton from "@/components/BaseListSkeleton.vue";

--- a/ui/src/pages/MewsListAuthor.vue
+++ b/ui/src/pages/MewsListAuthor.vue
@@ -73,7 +73,6 @@ import BaseEmptyList from "@/components/BaseEmptyList.vue";
 import BaseMewListItem from "@/components/BaseMewListItem.vue";
 import BaseAgentProfileLinkName from "@/components/BaseAgentProfileLinkName.vue";
 import { watch } from "vue";
-import { useToasts } from "@/stores/toasts";
 import { ProfilesStore } from "@holochain-open-dev/profiles";
 import { decodeHashFromBase64 } from "@holochain/client";
 import BaseButtonBack from "@/components/BaseButtonBack.vue";

--- a/ui/src/pages/MewsListAuthor.vue
+++ b/ui/src/pages/MewsListAuthor.vue
@@ -86,7 +86,6 @@ const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const profilesStore = (inject("profilesStore") as ComputedRef<ProfilesStore>)
   .value;
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 
 const pageLimit = 10;
 
@@ -144,8 +143,8 @@ const fetchNextPageInfiniteScroll = async (
   done(hasNextPage?.value);
 };
 
-watch(error, showError);
-watch(errorProfile, showError);
+watch(error, console.error);
+watch(errorProfile, console.error);
 
 onBeforeRouteLeave(() => {
   if (data.value && data.value.pages.length > 1) {

--- a/ui/src/pages/MewsListCashtag.vue
+++ b/ui/src/pages/MewsListCashtag.vue
@@ -70,7 +70,6 @@ import BaseMewListItemSkeleton from "@/components/BaseMewListItemSkeleton.vue";
 const route = useRoute();
 const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 const pageLimit = 5;
 
 const fetchCashtagMews = async (params: any) =>
@@ -104,7 +103,7 @@ const { data, error, fetchNextPage, hasNextPage, isInitialLoading, refetch } =
     refetchInterval: 1000 * 60 * 2, // 2 minutes
     refetchOnMount: true,
   });
-watch(error, showError);
+watch(error, console.error);
 
 const fetchNextPageInfiniteScroll = async (
   done: (hasMore?: boolean) => void

--- a/ui/src/pages/MewsListCashtag.vue
+++ b/ui/src/pages/MewsListCashtag.vue
@@ -61,7 +61,6 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/vue-query";
 import BaseEmptyList from "@/components/BaseEmptyList.vue";
 import BaseMewListItem from "@/components/BaseMewListItem.vue";
 import { watch } from "vue";
-import { useToasts } from "@/stores/toasts";
 import BaseButtonBack from "@/components/BaseButtonBack.vue";
 import BaseInfiniteScroll from "@/components/BaseInfiniteScroll.vue";
 import BaseListSkeleton from "@/components/BaseListSkeleton.vue";

--- a/ui/src/pages/MewsListHashtag.vue
+++ b/ui/src/pages/MewsListHashtag.vue
@@ -70,7 +70,6 @@ import BaseInfiniteScroll from "@/components/BaseInfiniteScroll.vue";
 const route = useRoute();
 const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 
 const pageLimit = 10;
 
@@ -107,7 +106,7 @@ const { data, error, fetchNextPage, hasNextPage, isInitialLoading, refetch } =
     refetchInterval: 1000 * 60 * 2, // 2 minutes
     refetchOnMount: true,
   });
-watch(error, showError);
+watch(error, console.error);
 
 const fetchNextPageInfiniteScroll = async (
   done: (hasMore?: boolean) => void

--- a/ui/src/pages/MewsListHashtag.vue
+++ b/ui/src/pages/MewsListHashtag.vue
@@ -61,7 +61,6 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/vue-query";
 import BaseEmptyList from "@/components/BaseEmptyList.vue";
 import BaseMewListItem from "@/components/BaseMewListItem.vue";
 import { watch } from "vue";
-import { useToasts } from "@/stores/toasts";
 import BaseButtonBack from "@/components/BaseButtonBack.vue";
 import BaseListSkeleton from "@/components/BaseListSkeleton.vue";
 import BaseMewListItemSkeleton from "@/components/BaseMewListItemSkeleton.vue";

--- a/ui/src/pages/MewsListMention.vue
+++ b/ui/src/pages/MewsListMention.vue
@@ -70,7 +70,6 @@ import BaseInfiniteScroll from "@/components/BaseInfiniteScroll.vue";
 const route = useRoute();
 const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 
 const pageLimit = 10;
 
@@ -107,7 +106,7 @@ const { data, error, fetchNextPage, hasNextPage, isInitialLoading, refetch } =
     refetchInterval: 1000 * 60 * 2, // 2 minutes
     refetchOnMount: true,
   });
-watch(error, showError);
+watch(error, console.error);
 
 const fetchNextPageInfiniteScroll = async (
   done: (hasMore?: boolean) => void

--- a/ui/src/pages/MewsListMention.vue
+++ b/ui/src/pages/MewsListMention.vue
@@ -61,7 +61,6 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/vue-query";
 import BaseEmptyList from "@/components/BaseEmptyList.vue";
 import BaseMewListItem from "@/components/BaseMewListItem.vue";
 import { watch } from "vue";
-import { useToasts } from "@/stores/toasts";
 import BaseButtonBack from "@/components/BaseButtonBack.vue";
 import BaseListSkeleton from "@/components/BaseListSkeleton.vue";
 import BaseMewListItemSkeleton from "@/components/BaseMewListItemSkeleton.vue";

--- a/ui/src/pages/MyNotifications.vue
+++ b/ui/src/pages/MyNotifications.vue
@@ -69,7 +69,6 @@ const client = (inject("client") as ComputedRef<AppAgentClient>).value;
 const useNotificationsReadStore = makeUseNotificationsReadStore(client);
 const { markRead, addNotificationStatus } = useNotificationsReadStore();
 const queryClient = useQueryClient();
-const { showError } = useToasts();
 
 const pageLimit = 10;
 
@@ -104,7 +103,7 @@ const { data, error, fetchNextPage, hasNextPage, refetch, isInitialLoading } =
     refetchInterval: 1000 * 60 * 2, // 2 minutes
     refetchOnMount: true,
   });
-watch(error, showError);
+watch(error, console.error);
 
 const fetchNextPageInfiniteScroll = async (
   done: (hasMore?: boolean) => void

--- a/ui/src/pages/MyNotifications.vue
+++ b/ui/src/pages/MyNotifications.vue
@@ -57,7 +57,6 @@ import { onBeforeRouteLeave } from "vue-router";
 import { pageHeightCorrection } from "@/utils/page-layout";
 import BaseNotification from "@/components/BaseNotification.vue";
 import BaseEmptyList from "@/components/BaseEmptyList.vue";
-import { useToasts } from "@/stores/toasts";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/vue-query";
 import { makeUseNotificationsReadStore } from "@/stores/notificationsRead";
 import { PaginationDirectionName, Notification } from "@/types/types";


### PR DESCRIPTION
Improves #193
Improves #188 

Reduce the noise of error toasts by only showing errors that arise when some *active* user action fails. I.e. A user's lick / unlick of a mew fails, or create mew fails, etc. 

If an error was generated passively (i.e. some data being fetched to populate a page's content), log it to console but do not show  a toast.