### PR TITLE
fix(ui): cached notificationsCount should only grow over time

### DIFF
--- a/ui/src/stores/notificationsRead.ts
+++ b/ui/src/stores/notificationsRead.ts
@@ -7,7 +7,6 @@ import { StateTree, defineStore } from "pinia";
 import { computed, ref } from "vue";
 import { Notification } from "@/types/types";
 import { encode, decode } from "@msgpack/msgpack";
-import { PersistedStateOptions } from "pinia-plugin-persistedstate";
 
 const notificationToKey = (notification: Notification) => {
   const keyObj = {
@@ -53,7 +52,9 @@ export const makeUseNotificationsReadStore = (client: AppAgentClient) =>
       }
 
       function setNotificationsCount(count: number) {
-        notificationsCount.value = count;
+        if (count > notificationsCount.value) {
+          notificationsCount.value = count;
+        }
       }
 
       return {


### PR DESCRIPTION
Cached notifications count should never shrink (i.e. if an authority has a smaller count than a prior queried authority, ignore it).

Improves #189 