### PR TITLE
fix(security): add svelte override for XSS and SSR vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "npm": ">=7.0.0"
   },
   "overrides": {
-    "@shoelace-style/shoelace": "2.11.0"
+    "@shoelace-style/shoelace": "2.11.0",
+    "svelte": "5.53.5"
   },
   "dependencies": {
     "wrangler": "^4.70.0"


### PR DESCRIPTION
## Summary
- Adds npm `overrides` entry for `svelte` → `5.53.5` to patch transitive dependency
- svelte 3.59.2 is pulled in via `@holochain-open-dev/stores` → `lit-svelte-stores` → `svelte`

## ⚠️ Risks and Limitations

**Override may not take effect automatically.** npm overrides require a clean install to apply:
```bash
rm -rf node_modules package-lock.json && npm install
```

**Major version jump (3 → 5).** `lit-svelte-stores` declares `"svelte": "^3.38.3"`. Forcing svelte 5 violates this range. However:
- Only the Svelte **store API** (`writable`, `readable`, `derived`, `get`) is used through `lit-svelte-stores`
- The store API is stable and largely unchanged from Svelte 3 → 5
- Still, this should be **tested thoroughly** before merging

**Alternative: wait for upstream.** If this override causes issues, the proper fix is for `@holochain-open-dev/stores` and `lit-svelte-stores` to update their svelte dependency.

## Dependabot Alerts Addressed (10)
- #152, #120 (Medium): XSS during SSR with contenteditable bind
- #144, #106 (Medium): SSR attribute spreading includes inherited prototype properties
- #143, #105 (Medium): SSR does not validate dynamic element tag names
- #142, #104 (Medium): XSS via spread attributes in SSR
- #136, #53 (Medium): Potential mXSS due to improper HTML escaping

## Test plan
- [ ] Clean install (`rm -rf node_modules package-lock.json && npm install`) — verify override takes effect
- [ ] `npm audit` no longer reports svelte vulnerabilities
- [ ] Application loads and renders correctly
- [ ] Profile-related functionality still works (uses @holochain-open-dev/stores)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)